### PR TITLE
Bump log4j-core in /org.dieschnittstelle.ess.mip.app.tomee

### DIFF
--- a/org.dieschnittstelle.ess.mip.app.tomee/pom.xml
+++ b/org.dieschnittstelle.ess.mip.app.tomee/pom.xml
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.11.1</version>
+            <version>2.13.2</version>
         </dependency>
         <!-- we provide the h2 database resources for the driver -->
         <dependency>


### PR DESCRIPTION
Bumps log4j-core from 2.11.1 to 2.13.2.

Signed-off-by: dependabot[bot] <support@github.com>